### PR TITLE
feat: update device compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ in Dart (still using the TDLib :p)
     - [ ] Notifications
 
 ## Compatibility
-* Samsung Galaxy Watch 4 (Wear OS 3)
+* Samsung Galaxy Watch 4/5 (Wear OS 3)
   * Runs very good, but sometimes can stutter
 * Oppo Watch (Wear OS 2)
   * Very strange unpredictable behaviour *(on v0.1.0, idk what's happening on v0.2.0)*
+* TicWatch Pro 3 Ultra (Wear OS 2)
+  * Some instabilities in visualization of videos
 
 Feel free to test on other devices and post an issue if something wrong happens :p
 


### PR DESCRIPTION
Just updated the list of compatible devices. Tested with Galaxy Watch 5 (40mm) (WearOS 3.5) and Ticwatch Pro 3 Ultra (WearOS 2.42)