### PR TITLE
Clarify API key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ You can download the latest built version from [releases page](https://github.co
   ```sh
   git clone https://github.com/HandyGram/HandyGram.git
   ```
+* Go into HandyGram directory
+  ```sh
+  cd handygram
+  ```
 * Copy/paste and rename `lib/src/telegram/api_config.dart.sample` to `api_config.dart` (this is ignored in `.gitignore` so it's ok to make commits with personal keys)
   ```sh
   cp lib/src/telegram/api_config.dart.sample lib/src/telegram/api_config.dart
@@ -74,10 +78,6 @@ You can download the latest built version from [releases page](https://github.co
 * To obtain API keys, go to [My Telegram](https://my.telegram.org) and log in
 * In [My Telegram](https://my.telegram.org), copy value of `App api_id` and paste for value of `apiId` in `api_config.dart`
 * In [My Telegram](https://my.telegram.org), copy value of `App api_hash` and paste for value of `apiHash` in `api_config.dart`
-* Go into HandyGram directory
-  ```sh
-  cd handygram
-  ```
 * Build HandyGram as apk
   ```sh
   flutter build apk

--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ You can download the latest built version from [releases page](https://github.co
   ```sh
   git clone https://github.com/HandyGram/HandyGram.git
   ```
-* Obtain API keys from [My Telegram](https://my.telegram.org)
-* Insert your keys in `lib/src/telegram/api_config.dart`
+* Copy/paste and rename `lib/src/telegram/api_config.dart.sample` to `api_config.dart` (this is ignored in `.gitignore` so it's ok to make commits with personal keys)
+  ```sh
+  cp lib/src/telegram/api_config.dart.sample lib/src/telegram/api_config.dart
+  ```
+* To obtain API keys, go to [My Telegram](https://my.telegram.org) and log in
+* In [My Telegram](https://my.telegram.org), copy value of `App api_id` and paste for value of `apiId` in `api_config.dart`
+* In [My Telegram](https://my.telegram.org), copy value of `App api_hash` and paste for value of `apiHash` in `api_config.dart`
 * Go into HandyGram directory
   ```sh
   cd handygram

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ in Dart (still using the TDLib :p)
   * Runs very good, but sometimes can stutter
 * TicWatch Pro 3 Ultra (Wear OS 2)
   * Some instabilities in visualization of videos
+* Pixel Watch
+  * Occasional stuttering
+  * Some instabilities in visualization of videos (crashes, stuttering)
+  * Scrolling with crown is buggy
 
 Feel free to test on other devices and post an issue if something wrong happens :p
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can download the latest built version from [releases page](https://github.co
   ```
 * Go into HandyGram directory
   ```sh
-  cd handygram
+  cd HandyGram
   ```
 * Copy/paste and rename `lib/src/telegram/api_config.dart.sample` to `api_config.dart` (this is ignored in `.gitignore` so it's ok to make commits with personal keys)
   ```sh


### PR DESCRIPTION
The original instructions were a little ambiguous and I had to do some trial and error to get it working for me. 